### PR TITLE
Fix: Support nested List[List[Compound]] structures with None subtype

### DIFF
--- a/ftb_snbt_lib/tag.py
+++ b/ftb_snbt_lib/tag.py
@@ -147,6 +147,9 @@ class List(Base, list):
     @classmethod
     def cast_item(cls, item):
         if cls.subtype is None:
+            # If subtype cannot be inferred, accept Base types as-is
+            if isinstance(item, Base):
+                return item
             raise InvalidTypeError(item, cls)
         
         if not isinstance(item, cls.subtype):


### PR DESCRIPTION
- Modified List.cast_item() to accept Base type items when subtype is None
- This fixes parsing errors for complex nested list structures like those found in draconicevolution:config_properties
- Example: [[{'': 'BOOLEAN'}, {...}], [{...}, {...}]]
- Resolves InvalidTypeError when parsing creative.snbt with empty string keys in nested Compound objects